### PR TITLE
Remove result and progress messages, change type for sizes and hash

### DIFF
--- a/ansys/api/utilities/filetransfer/v1/file_transfer_service.proto
+++ b/ansys/api/utilities/filetransfer/v1/file_transfer_service.proto
@@ -37,7 +37,7 @@ message ProgressResponse {
 message SHA1 {
 
     // The SHA-1 hash value rendered as a hexadecimal number (40 digits long).
-    bytes hex_digest = 1;
+    string hex_digest = 1;
 }
 
 //


### PR DESCRIPTION
Remove the `Result` message in favor of using gRPC status codes.

Change all unsigned integer types to be signed, following https://cloud.google.com/apis/design/design_patterns#integer_types

Change the type of the SHA1 hexdigest to string, to avoid encoding issues.