### PR TITLE
feat: tech review

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     versioning-strategy: "increase"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: GitHub CI
 
-# run only on main branch.  This avoids duplicated actions on PRs
+# run only on main branch. This avoids duplicated actions on PRs
 on:
   pull_request:
   push:
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: '3.9'
+  MAIN_PYTHON_VERSION: '3.10'
   PACKAGE_NAME: 'ansys-api-tools-filetransfer'
 
 jobs:
@@ -40,36 +40,23 @@ jobs:
         run: |
           pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
 
-  check-version:
-    name: "Check version is bumped"
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
-    steps:
-      - name: "Check out repository"
-        uses: actions/checkout@v4
-      - name: "Check version is changed"
-        run: |
-          git fetch origin $BASE_BRANCH
-
-          NUM_CHARS=$(git diff --ignore-all-space origin/$BASE_BRANCH -- src/ansys/api/tools/filetransfer/VERSION | wc -c)
-
-          if [ $NUM_CHARS -eq 0 ]; then
-            echo "Version is not bumped.  Please update the version in src/ansys/api/tools/filetransfer/VERSION"
-            exit 1
-          fi
-        env:
-          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
-
-
-  release-pypi-private:
-    name: "Release to private PyPI"
+  release:
+    name: "Release package"
     runs-on: ubuntu-latest
     needs: [build-library]
-    if: github.event_name == 'push' && github.ref_type == 'branch' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     steps:
-      - name: "Release to the private PyPI repository"
-        uses: ansys/actions/release-pypi-private@v5
+      - name: "Release to the public PyPI repository"
+        uses: ansys/actions/release-pypi-public@v5
         with:
           library-name:  ${{ env.PACKAGE_NAME }}
           twine-username: "__token__"
-          twine-token: ${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}
+          twine-token: ${{ secrets.PYPI_TOKEN }}
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          files: |
+            ./**/*.whl
+            ./**/*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # Virtual environment
 venv
+.venv
 
 # Distribution / packaging
 .Python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,5 @@ repos:
   rev: v0.2.8
   hooks:
   - id: add-license-headers
+    args:
+    - --start_year=2022

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,12 @@
+# Contributors
+
+## Project Lead or Owner
+
+* [Dominik Gresch](https://github.com/greschd)
+
+## Individual Contributors
+
+* [Alexander Kaszynski](https://github.com/akaszynski)
+* [Dominik Gresch](https://github.com/greschd)
+* [Roberto Pastor Muela](https://github.com/RobPasMue)
+* [Udo Tremel](https://github.com/ansutremel)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
         name=package_name,
         version=version,
         author="ANSYS, Inc.",
-        author_email="support@ansys.com",
+        author_email="pyansys.core@ansys.com",
         description=description,
         long_description=long_description,
         long_description_content_type="text/markdown",
@@ -48,4 +48,9 @@ if __name__ == "__main__":
             ],
         },
         cmdclass=CMDCLASS_OVERRIDE,
+        project_urls={
+            "Documentation": f"https://github.com/ansys-internal/{package_name}/#readme",
+            "Source": f"https://github.com/ansys-internal/{package_name}/",
+            "Tracker": f"https://github.com/ansys-internal/{package_name}/issues/",
+        },
     )

--- a/src/ansys/api/tools/filetransfer/__init__.py
+++ b/src/ansys/api/tools/filetransfer/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/api/tools/filetransfer/v1/file_transfer_service.proto
+++ b/src/ansys/api/tools/filetransfer/v1/file_transfer_service.proto
@@ -1,5 +1,4 @@
-// Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
-// Copyright 2022 ANSYS, Inc. Unauthorized use, distribution, or duplication is prohibited.
+// Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 // SPDX-License-Identifier: MIT
 //
 //


### PR DESCRIPTION
Modifications suggested:
* Adding ``CONTRIBUTORS.md`` file
* Adapting license headers with start year 2022
* Removing release to private PyPI in favor of public PyPI
* Avoid automatic releasing on push to main - this should be done in a controlled manner by using tags.
* Upgrading main Python version to 3.10 for build process
* Changing dependabot updates to a weekly basis (now that the project is stable and will be released)
* Removing version bump check on all PRs (not needed anymore since releasing should not be done directly on the main branch and without tags)
* Adding extra project URLs to setup.py
* Removing wrong license headers: ``// Copyright 2022 ANSYS, Inc. Unauthorized use, distribution, or duplication is prohibited.``