### PR TITLE
Dependency updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: '3.10'
+  MAIN_PYTHON_VERSION: '3.14'
   PACKAGE_NAME: 'ansys-api-tools-filetransfer'
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 23.12.1
+  rev: 26.1.0
   hooks:
   - id: black
 - repo: https://github.com/pycqa/isort
-  rev: 5.13.2
+  rev: 8.0.1
   hooks:
   - id: isort
 - repo: https://github.com/pycqa/flake8
-  rev: 7.0.0
+  rev: 7.3.0
   hooks:
   - id: flake8
 - repo: https://github.com/ansys/pre-commit-hooks
-  rev: v0.2.8
+  rev: v0.5.2
   hooks:
   - id: add-license-headers
     args:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 ANSYS, Inc. All rights reserved.
+Copyright (c) 2022 - 2026 ANSYS, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools >= 42.0.0", "wheel", "ansys_tools_protoc_helper>=0.4.0"]
+requires = ["setuptools >= 42.0.0", "wheel", "ansys_tools_protoc_helper>=0.7.0"]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,1 +1,1 @@
-pre-commit==4.3.0
+pre-commit==4.5.1

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ if __name__ == "__main__":
         long_description_content_type="text/markdown",
         url=f"https://github.com/ansys/{package_name}",
         license="MIT",
-        python_requires=">=3.7",
-        install_requires=["grpcio~=1.17", "protobuf>=3.19,<7"],
+        python_requires=">=3.10",
+        install_requires=["grpcio~=1.17", "protobuf>=5.29"],
         package_dir={"": "src"},
         packages=setuptools.find_namespace_packages("src", include=("ansys.*",)),
         package_data={

--- a/src/ansys/api/tools/filetransfer/__init__.py
+++ b/src/ansys/api/tools/filetransfer/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/api/tools/filetransfer/v1/file_transfer_service.proto
+++ b/src/ansys/api/tools/filetransfer/v1/file_transfer_service.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
 // SPDX-License-Identifier: MIT
 //
 //


### PR DESCRIPTION
Breaking changes:
- Bump the minimum Python version to 3.10
- Bump the minimum protobuf version to 5.29

Other functional changes:
- Bump the minimum version for ansys-tools-protoc-helper to 0.7.0
- Drop the upper bound for the protobuf version

Non-functional (dev only) changes:
- Update the main Python version in CI to 3.14
- Update pre-commit to 4.5.1
- Update pre-commit hooks