### PR TITLE
Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,17 @@ updates:
     schedule:
       interval: "weekly"
     versioning-strategy: "increase"
+    cooldown:
+      include:
+        - '*'
+      default-days: 7
+    exclude-paths:
+      - "pyproject.toml" # build dependencies in pyproject.toml use open intervals
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      include:
+        - '*'
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           twine-token: ${{ secrets.PYPI_TOKEN }}
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           generate_release_notes: true
           files: |


### PR DESCRIPTION
- Add a cooldown period of 7 days for all updates.
- For the pip dependencies, exclude `pyproject.toml` since the build dependencies specified there anyway use an open interval.
- Pin the commit SHA for `softprops/action-gh-release`.